### PR TITLE
 feat: Websockets and backend conection (TM Week 3)  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 main
 ribal-backend*
 output_*.csv
+
+logs/

--- a/Week03/build.sh
+++ b/Week03/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+go build -C receiver/
+go build -C simulator/

--- a/Week03/receiver/config/config.go
+++ b/Week03/receiver/config/config.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"ribal-backend-receiver/logger"
+)
+
+type Config struct {
+	RingBufferSize int
+	BufferSize     int
+}
+
+// default settings
+
+var Default = Config{RingBufferSize: 10, BufferSize: 4096}
+
+// loads configuration
+func Load(path string) (Config, error) {
+	cfg := Default
+
+	file, err := os.Open(path)
+	if err != nil {
+		// Si el archivo no existe, devolvemos la configuración por defecto
+		if os.IsNotExist(err) {
+			logger.Info("Config file not found, using defaults")
+			return cfg, nil
+		}
+		return cfg, err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&cfg); err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+
+}

--- a/Week03/receiver/config/config.json
+++ b/Week03/receiver/config/config.json
@@ -1,0 +1,4 @@
+{
+    "RingBufferSize": 10,
+    "BufferSize": 4096
+}

--- a/Week03/receiver/csvutil/csvutil.go
+++ b/Week03/receiver/csvutil/csvutil.go
@@ -1,0 +1,54 @@
+package csvutil
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"ribal-backend-receiver/sensors"
+	"strconv"
+	"time"
+)
+
+// setCSVWriter configures and return the csv file writer and a function
+// to close the writer
+func SetUpCSVWriter() (*csv.Writer, func()) {
+
+	// Create file
+	filename := fmt.Sprintf("output_%s.csv", time.Now().Format("20060102_150405"))
+
+	f, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create writer
+	writer := csv.NewWriter(f)
+
+	// write header in log
+	writer.Write([]string{"timestamp", "magnitude", "avg", "min", "max"})
+
+	// Retunrs thew writer and a function to close it
+	return writer, func() {
+		writer.Flush()
+		f.Close()
+	}
+}
+
+// given a records an a csv adds it to the csv
+
+func AddToCSV(writer csv.Writer, data sensors.Record) {
+
+	// Format new line
+	record := []string{
+		data.Timestamp,
+		data.Magnitude,
+		strconv.FormatFloat(data.Avg, 'f', -1, 64),
+		strconv.FormatFloat(data.Min, 'f', -1, 64),
+		strconv.FormatFloat(data.Max, 'f', -1, 64),
+	}
+
+	// Add new line
+	writer.Write(record)
+	writer.Flush()
+
+}

--- a/Week03/receiver/csvutil/csvutil.go
+++ b/Week03/receiver/csvutil/csvutil.go
@@ -4,10 +4,15 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"path/filepath"
 	"ribal-backend-receiver/logger"
 	"ribal-backend-receiver/sensors"
 	"strconv"
 	"time"
+)
+
+const (
+	logDir = "logs/data"
 )
 
 var (
@@ -19,8 +24,10 @@ var (
 // creates the loger file
 func init() {
 
+	os.MkdirAll(logDir, 0755)
+
 	// Create file
-	filename = fmt.Sprintf("logs/data/data-output-%s.csv", time.Now().Format("2006-01-02_15-04-05"))
+	filename = filepath.Join(logDir, fmt.Sprintf("data-output-%s.csv", time.Now().Format("2006-01-02_15-04-05")))
 
 	createCSV()
 

--- a/Week03/receiver/csvutil/csvutil.go
+++ b/Week03/receiver/csvutil/csvutil.go
@@ -48,8 +48,6 @@ func createCSV() {
 // adds a record to the csv
 func AddToCSV(data sensors.Record) {
 
-	fmt.Print(data)
-
 	// Format new line
 	record := []string{
 		data.Timestamp,

--- a/Week03/receiver/csvutil/csvutil.go
+++ b/Week03/receiver/csvutil/csvutil.go
@@ -4,39 +4,51 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"ribal-backend-receiver/logger"
 	"ribal-backend-receiver/sensors"
 	"strconv"
 	"time"
 )
 
-// setCSVWriter configures and return the csv file writer and a function
-// to close the writer
-func SetUpCSVWriter() (*csv.Writer, func()) {
+var (
+	writer   *csv.Writer
+	file     *os.File
+	filename string
+)
+
+// creates the loger file
+func init() {
 
 	// Create file
-	filename := fmt.Sprintf("output_%s.csv", time.Now().Format("20060102_150405"))
+	filename = fmt.Sprintf("logs/data/data-output-%s.csv", time.Now().Format("2006-01-02_15-04-05"))
 
+	createCSV()
+
+	logger.Info("CSV file was created at " + filename)
+
+}
+
+// creates the csv file
+func createCSV() {
 	f, err := os.Create(filename)
 	if err != nil {
+		logger.Error(err.Error())
 		panic(err)
 	}
 
+	file = f
+
 	// Create writer
-	writer := csv.NewWriter(f)
+	writer = csv.NewWriter(f)
 
 	// write header in log
 	writer.Write([]string{"timestamp", "magnitude", "avg", "min", "max"})
-
-	// Retunrs thew writer and a function to close it
-	return writer, func() {
-		writer.Flush()
-		f.Close()
-	}
 }
 
-// given a records an a csv adds it to the csv
+// adds a record to the csv
+func AddToCSV(data sensors.Record) {
 
-func AddToCSV(writer csv.Writer, data sensors.Record) {
+	fmt.Print(data)
 
 	// Format new line
 	record := []string{
@@ -51,4 +63,14 @@ func AddToCSV(writer csv.Writer, data sensors.Record) {
 	writer.Write(record)
 	writer.Flush()
 
+}
+
+// Overwrites (cleans) the current CSV file, preserving the same filename
+func ClearCSV() {
+	if file != nil {
+		file.Close()
+	}
+	createCSV()
+
+	logger.Info("CSV file was cleared out")
 }

--- a/Week03/receiver/go.mod
+++ b/Week03/receiver/go.mod
@@ -2,4 +2,4 @@ module ribal-backend-receiver
 
 go 1.25.1
 
-require github.com/gorilla/websocket v1.5.3 // indirect
+require github.com/gorilla/websocket v1.5.3

--- a/Week03/receiver/go.mod
+++ b/Week03/receiver/go.mod
@@ -1,3 +1,5 @@
 module ribal-backend-receiver
 
 go 1.25.1
+
+require github.com/gorilla/websocket v1.5.3 // indirect

--- a/Week03/receiver/go.mod
+++ b/Week03/receiver/go.mod
@@ -1,0 +1,3 @@
+module ribal-backend-receiver
+
+go 1.25.1

--- a/Week03/receiver/go.sum
+++ b/Week03/receiver/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/Week03/receiver/httpws/httpws.go
+++ b/Week03/receiver/httpws/httpws.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"ribal-backend-receiver/csvutil"
 	"ribal-backend-receiver/logger"
 	"ribal-backend-receiver/ringbuffer"
 	"ribal-backend-receiver/sensors"
@@ -71,6 +72,10 @@ func postCmd(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
+	response := map[string]string{
+		"status": "ok",
+	}
+
 	switch strings.ToUpper(cmd.Action) {
 
 	case "CONTINUE":
@@ -81,10 +86,15 @@ func postCmd(w http.ResponseWriter, r *http.Request) {
 		state.SetPower(false)
 		logger.Action(cmd.Action)
 
-	}
+	case "CLEAR", "CLEAN":
+		csvutil.ClearCSV()
+		logger.Action(cmd.Action)
 
-	response := map[string]string{
-		"status": "ok",
+	default:
+		response["msg"] = cmd.Action + " action was not found"
+		response["status"] = "error"
+		logger.Error(response["msg"])
+
 	}
 
 	json.NewEncoder(w).Encode(response)

--- a/Week03/receiver/httpws/httpws.go
+++ b/Week03/receiver/httpws/httpws.go
@@ -1,0 +1,107 @@
+package httpws
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"ribal-backend-receiver/sensors"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// WS updatesr
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// Set of clients
+var (
+	clients   = make(map[*websocket.Conn]struct{}) // SET
+	clientsMu sync.RWMutex                         // RWMutex used to avoid reading and writing at the same time
+)
+
+func StartHttpWSServer() {
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/stream", wsStreamHandler)
+
+	addr := ":8081"
+	fmt.Println("Servidor HTTP escuchando en", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		panic(err)
+	}
+
+}
+
+/**
+* Web Sockets
+ */
+
+// Conection to /api/stream
+func wsStreamHandler(w http.ResponseWriter, r *http.Request) {
+
+	// Tries to upgrade connection
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		fmt.Printf("upgrade error: %v", err)
+		return
+	}
+	addClient(conn) // alta
+
+	// Prints the number of clients
+	fmt.Printf("WS CONNECT (%d activos)\n", func() int { clientsMu.RLock(); defer clientsMu.RUnlock(); return len(clients) }())
+
+	// Discard readings
+	go func(c *websocket.Conn) {
+		defer removeClient(c)
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				fmt.Printf("WS CLOSE: %v\n", err)
+				return
+			}
+		}
+	}(conn)
+}
+
+// Adds a client to set of clients
+func addClient(c *websocket.Conn) {
+
+	clientsMu.Lock()        // Blocks new access to read clients
+	clients[c] = struct{}{} // Adds the key to the Set
+	clientsMu.Unlock()      // Unblocks the access
+}
+
+// Remove a client from the set of clients
+func removeClient(c *websocket.Conn) {
+	clientsMu.Lock()   // Blocks acces
+	delete(clients, c) // Delete the client from the server
+	clientsMu.Unlock() // Unblocks the st
+	_ = c.Close()      // Closes the connection with that specific client
+}
+
+func BroadcastJSON(dataSensor sensors.Record) {
+
+	// Transforms it to a JSON
+	jsonData, err := json.Marshal(dataSensor)
+	if err != nil {
+		return
+	}
+
+	// Locks the client to read it
+	clientsMu.RLock()
+	defer clientsMu.RUnlock()
+
+	for c := range clients {
+		// Limit to write
+		_ = c.SetWriteDeadline(time.Now().Add(10 * time.Second))
+
+		// writes message
+		if err := c.WriteMessage(websocket.TextMessage, jsonData); err != nil {
+			// if the brodcast fails shutdown the connection
+			go removeClient(c)
+		}
+	}
+}

--- a/Week03/receiver/logger/logger.go
+++ b/Week03/receiver/logger/logger.go
@@ -1,0 +1,58 @@
+package logger
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	logDir = "logs/logs"
+)
+
+var (
+	logFile *os.File
+	logger  *log.Logger
+)
+
+// Create the configuration of the file
+func init() {
+	os.MkdirAll(logDir, 0755)
+
+	filename := time.Now().Format("log-2006-01-02_15-04-05.txt")
+	fullPath := filepath.Join(logDir, filename)
+
+	var err error
+	logFile, err = os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		log.Fatalf("The file could not be created: %v", err)
+	}
+	logger = log.New(logFile, "", log.LstdFlags)
+}
+
+// Writes info to the file
+func Info(msg string) {
+	WriteToLog("[INFO] " + msg)
+}
+
+// Writes an error to the file
+func Error(msg string) {
+	WriteToLog("[ERROR] " + msg)
+}
+
+// WriteToLog writes a message to the log including the date and time.
+func WriteToLog(msg string) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	logger.Printf("[%s] %s", timestamp, msg)
+}
+
+// Action writes a message to the log with a custom [ACTION] tag.
+func Action(msg string) {
+	WriteToLog("[ACTION] " + msg)
+}
+
+// Not used
+func Close() {
+	logFile.Close()
+}

--- a/Week03/receiver/main.go
+++ b/Week03/receiver/main.go
@@ -88,8 +88,6 @@ func handleClient(conn net.Conn, buffer chan<- sensors.Record) {
 // Recieve the data from sensors, writes it down on the CSV, sends it through webscokets and adds it to the round buffer
 func recieveData(buffer chan sensors.Record, ring *ringbuffer.RingBuffer[sensors.Record]) {
 
-	writer, closeFile := csvutil.SetUpCSVWriter()
-	defer closeFile()
 	for rec := range buffer {
 
 		// If it is power on avoids scripture
@@ -98,7 +96,7 @@ func recieveData(buffer chan sensors.Record, ring *ringbuffer.RingBuffer[sensors
 		}
 
 		// CSV
-		csvutil.AddToCSV(*writer, rec)
+		csvutil.AddToCSV(rec)
 
 		// Broadcast
 		httpws.BroadcastJSON(rec)

--- a/Week03/receiver/main.go
+++ b/Week03/receiver/main.go
@@ -7,8 +7,10 @@ import (
 	"net"
 	"ribal-backend-receiver/csvutil"
 	"ribal-backend-receiver/httpws"
+	"ribal-backend-receiver/logger"
 	"ribal-backend-receiver/ringbuffer"
 	"ribal-backend-receiver/sensors"
+	"ribal-backend-receiver/state"
 )
 
 func main() {
@@ -19,11 +21,12 @@ func main() {
 	// ring buffer
 	ring := ringbuffer.NewRing[sensors.Record](10)
 
-	// TCP connction with backends
+	// TCP connction with
 	go acceptIncomeConn(writeBuffer)
 
-	go writeBufferToCSV(writeBuffer, ring)
+	go recieveData(writeBuffer, ring)
 
+	// Start http server
 	httpws.StartHttpWSServer(ring)
 
 }
@@ -35,15 +38,20 @@ func acceptIncomeConn(buffer chan<- sensors.Record) {
 	listener, err := net.Listen("tcp", "localhost:8080")
 	if err != nil {
 		fmt.Println("Error:", err)
+		logger.Error(err.Error())
+
 		return
 	}
 	defer listener.Close()
+
+	logger.Info("TCP server listening on port 8080 (sensors)")
 
 	for {
 		// Accept incoming connections
 		conn, err := listener.Accept()
 		if err != nil {
 			fmt.Println("Error:", err)
+			logger.Error(err.Error())
 			continue
 		}
 
@@ -60,31 +68,42 @@ func handleClient(conn net.Conn, buffer chan<- sensors.Record) {
 	dec := json.NewDecoder(conn)
 
 	for {
+		// Parses data
 		var rec sensors.Record
 		if err := dec.Decode(&rec); err != nil {
 			if err == io.EOF {
-				fmt.Println("client disconnected")
+				logger.Info("Client disconnected to TCP 8080 server")
 				return
 			}
 			fmt.Println("decode error:", err)
+			logger.Error("decode error" + err.Error())
 			return
 		}
 
+		// Adds it to chanel
 		buffer <- rec
 	}
 }
 
-// writes buffer into the csv
-func writeBufferToCSV(buffer chan sensors.Record, ring *ringbuffer.RingBuffer[sensors.Record]) {
+// Recieve the data from sensors, writes it down on the CSV, sends it through webscokets and adds it to the round buffer
+func recieveData(buffer chan sensors.Record, ring *ringbuffer.RingBuffer[sensors.Record]) {
 
 	writer, closeFile := csvutil.SetUpCSVWriter()
 	defer closeFile()
 	for rec := range buffer {
 
+		// If it is power on avoids scripture
+		if !state.IsPowerOn() {
+			continue
+		}
+
+		// CSV
 		csvutil.AddToCSV(*writer, rec)
 
+		// Broadcast
 		httpws.BroadcastJSON(rec)
 
+		// Ring buffer
 		ring.Add(rec)
 	}
 }

--- a/Week03/receiver/main.go
+++ b/Week03/receiver/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"ribal-backend-receiver/config"
 	"ribal-backend-receiver/csvutil"
 	"ribal-backend-receiver/httpws"
 	"ribal-backend-receiver/logger"
@@ -15,11 +16,13 @@ import (
 
 func main() {
 
+	cfg, _ := config.Load("config/config.json")
+
 	// buffer to write into the csv
-	writeBuffer := make(chan sensors.Record, 4096)
+	writeBuffer := make(chan sensors.Record, cfg.BufferSize)
 
 	// ring buffer
-	ring := ringbuffer.NewRing[sensors.Record](10)
+	ring := ringbuffer.NewRing[sensors.Record](cfg.RingBufferSize)
 
 	// TCP connction with
 	go acceptIncomeConn(writeBuffer)

--- a/Week03/receiver/ringbuffer/ringbuffer.go
+++ b/Week03/receiver/ringbuffer/ringbuffer.go
@@ -1,7 +1,6 @@
 package ringbuffer
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -51,8 +50,6 @@ func NewRing[T any](size int) *RingBuffer[T] {
 
 // Removes the oldest and adds a new one
 func (ring *RingBuffer[T]) Add(v T) {
-
-	fmt.Print(ring.Read())
 
 	// Blocks to write
 	ring.mu.Lock()

--- a/Week03/receiver/ringbuffer/ringbuffer.go
+++ b/Week03/receiver/ringbuffer/ringbuffer.go
@@ -1,0 +1,92 @@
+package ringbuffer
+
+import (
+	"fmt"
+	"sync"
+)
+
+type RingBuffer[T any] struct {
+	mu   sync.RWMutex
+	head *ringNode[T]
+	size int
+}
+
+type ringNode[T any] struct {
+	ele  T
+	next *ringNode[T]
+}
+
+// Creates the ring
+func NewRing[T any](size int) *RingBuffer[T] {
+
+	// Checks if the Ring can be created
+	if size < 2 {
+		panic("The size of the Ring Buffer must be atleast 2")
+	}
+
+	// First
+	firstNode := &ringNode[T]{}
+
+	// Before node
+	pre := firstNode
+
+	// Inserts n-1 nodes
+	for i := 0; i < size-1; i++ {
+
+		n := &ringNode[T]{}
+
+		pre.next = n
+
+		pre = n
+
+	}
+
+	// Last node points to the first
+
+	pre.next = firstNode
+
+	return &RingBuffer[T]{head: firstNode, size: size}
+
+}
+
+// Removes the oldest and adds a new one
+func (ring *RingBuffer[T]) Add(v T) {
+
+	fmt.Print(ring.Read())
+
+	// Blocks to write
+	ring.mu.Lock()
+
+	// Overwrites
+	ring.head.ele = v
+
+	// Rotation
+	ring.head = ring.head.next
+
+	ring.mu.Unlock()
+}
+
+// Returns the size of the ring
+
+func (ring *RingBuffer[T]) Size() int {
+
+	return ring.size
+}
+
+// Returns the content of the ring from old to new
+func (ring *RingBuffer[T]) Read() []T {
+
+	buffer := make([]T, 0, ring.size)
+
+	ring.mu.RLock()
+	defer ring.mu.RUnlock()
+
+	for n := ring.head; ; n = n.next {
+		buffer = append(buffer, n.ele)
+		if n.next == ring.head {
+			break
+		}
+	}
+	return buffer
+
+}

--- a/Week03/receiver/send-order.sh
+++ b/Week03/receiver/send-order.sh
@@ -1,0 +1,6 @@
+
+
+
+curl -X POST http://localhost:8081/api/commands \
+     -H "Content-Type: application/json" \
+     -d "{\"action\":\"$1\"}"

--- a/Week03/receiver/sensors/sensors.go
+++ b/Week03/receiver/sensors/sensors.go
@@ -1,0 +1,10 @@
+package sensors
+
+// Stores the data before to be sended
+type Record struct {
+	Timestamp string // Time
+	Magnitude string
+	Min       float64
+	Max       float64
+	Avg       float64
+}

--- a/Week03/receiver/state/state.go
+++ b/Week03/receiver/state/state.go
@@ -1,0 +1,22 @@
+package state
+
+import "sync"
+
+var (
+	mu      sync.RWMutex
+	PowerOn bool = true
+)
+
+// Set Power
+func SetPower(on bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	PowerOn = on
+}
+
+// Get power
+func IsPowerOn() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return PowerOn
+}

--- a/Week03/simulator/README.md
+++ b/Week03/simulator/README.md
@@ -1,0 +1,1 @@
+"# TM-software-H11" 

--- a/Week03/simulator/go.mod
+++ b/Week03/simulator/go.mod
@@ -1,0 +1,3 @@
+module ribal-backend
+
+go 1.25.1

--- a/Week03/simulator/main.go
+++ b/Week03/simulator/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"ribal-backend/sensors"
+	"ribal-backend/stats"
+	"time"
+)
+
+func main() {
+
+	// Context ensures that when the program is closed
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// channel of reading
+	readings := make(chan sensors.Data, 4096)
+
+	// Stores all the data of the sensors
+	data := make(map[string][]float64)
+
+	// Starts all the sensors
+	sensors.StartSensors(ctx, readings, "sensors.json")
+
+	// For each second
+	ticker := time.NewTicker(time.Millisecond * 100)
+	defer ticker.Stop()
+
+	// TCP connection
+	conn, err := net.Dial("tcp", "localhost:8080")
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	defer conn.Close()
+
+	// Register the output of the sensors
+	runProcessingLoop(ctx, readings, data, ticker, conn)
+
+}
+
+// SendData sends de data to the server
+// For each magnitude with values, it computes avg/min/max,
+// sends [timestamp, magnitude, avg, min, max] to the backend,
+// and clears the slice for the next batch.
+func SendData(data map[string][]float64, t time.Time, conn net.Conn) {
+
+	// For each magnitude
+	for magnitude, values := range data {
+
+		// Avoid error in case there is not new data
+		if len(values) == 0 {
+			continue
+		}
+
+		// Calculates data
+		avg, min, max := stats.CalculateStats(values)
+
+		// Format new line
+		record := sensors.Record{Timestamp: t.Format(time.RFC3339), Magnitude: magnitude, Min: min, Max: max, Avg: avg}
+
+		// Transform to json
+		msg, err := json.Marshal(record)
+
+		if err != nil {
+			fmt.Println("error:", err)
+		}
+
+		// send to server
+		conn.Write(msg)
+
+		// Remove content
+		data[magnitude] = data[magnitude][:0]
+	}
+}
+
+// runProcessingLoops recives the output of the sensors, stores it and obtains the main stats
+func runProcessingLoop(ctx context.Context, readings chan sensors.Data, data map[string][]float64, ticker *time.Ticker, conn net.Conn) {
+	// Forever
+	for {
+
+		select {
+
+		// Adds the reading to de batch
+		case d := <-readings:
+			data[d.Name] = append(data[d.Name], d.Measure)
+
+		// Each seconds writes the log
+		case t := <-ticker.C:
+			SendData(data, t, conn)
+
+		// Stop app
+		case <-ctx.Done():
+			return
+
+		}
+
+	}
+}

--- a/Week03/simulator/sensors.json
+++ b/Week03/simulator/sensors.json
@@ -1,0 +1,58 @@
+[
+    {
+        "Name": "voltaje",
+        "Number": 1,
+        "Unit": "V",
+        "Period": 50,
+        "Avg": 12,
+        "Sdev": 1
+    },
+    {
+        "Name": "voltaje",
+        "Number": 2,
+        "Unit": "V",
+        "Period": 50,
+        "Avg": 12,
+        "Sdev": 3
+    },
+    {
+        "Name": "voltaje",
+        "Number": 3,
+        "Unit": "V",
+        "Period": 55,
+        "Avg": 12,
+        "Sdev": 2.5
+    },
+    {
+        "Name": "voltaje",
+        "Number": 4,
+        "Unit": "V",
+        "Period": 60,
+        "Avg": 12,
+        "Sdev": 3
+    },
+    {
+        "Name": "distance",
+        "Number": 1,
+        "Unit": "cm",
+        "Period": 20,
+        "Avg": 20,
+        "Sdev": 1
+    },
+    {
+        "Name": "distance",
+        "Number": 2,
+        "Unit": "cm",
+        "Period": 23,
+        "Avg": 20,
+        "Sdev": 0.5
+    },
+    {
+        "Name": "distance",
+        "Number": 3,
+        "Unit": "cm",
+        "Period": 23,
+        "Avg": 20,
+        "Sdev": 2
+    }
+]

--- a/Week03/simulator/sensors/sensors.go
+++ b/Week03/simulator/sensors/sensors.go
@@ -1,0 +1,110 @@
+package sensors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"time"
+)
+
+type Sensor struct {
+	Name   string
+	Number int64
+	Unit   string
+	Period time.Duration // on ms
+	Avg    float64
+	Sdev   float64
+}
+
+type Data struct {
+	Measure   float64
+	Unit      string
+	Timestamp time.Time
+	Name      string
+	Number    int64
+}
+
+// Stores the data before to be sended
+type Record struct {
+	Timestamp string // Time
+	Magnitude string
+	Min       float64
+	Max       float64
+	Avg       float64
+}
+
+// Using the properties of a Sensor generates following a normal distribution values
+func (s Sensor) Read() Data {
+	v := s.Avg + s.Sdev*rand.NormFloat64() // N(Avg, Sdev)
+	return Data{
+		Timestamp: time.Now(),
+		Measure:   v,
+		Name:      s.Name,
+		Number:    s.Number,
+		Unit:      s.Unit,
+	}
+}
+
+// StartMeasuring starts a goroutine that periodically sends readings to out.
+func (s Sensor) StartMeasuring(ctx context.Context, out chan<- Data) {
+
+	// Starts the gororutine, uses anonymous function
+	go func() {
+
+		ticker := time.NewTicker(s.Period * time.Millisecond) // Creates a new ticker for each period
+		defer ticker.Stop()                                   // Ensures that the ticker is properly removed
+
+		// Un
+		for {
+
+			// Wait until a case ocurrs
+			select {
+
+			// Tick
+			case <-ticker.C:
+				out <- s.Read()
+
+			// Stop app
+			case <-ctx.Done():
+				return
+
+			}
+
+		}
+
+	}()
+}
+
+// StartSensors starts sensor goroutines that write to 'readings'.
+// needs the ctx, reading chan and the configuration path
+// They stop when ctx is canceled. This function does not close 'readings'.
+func StartSensors(ctx context.Context, readings chan<- Data, jsonPath string) {
+
+	// Open json file
+	jsonFile, err := os.Open(jsonPath)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer jsonFile.Close()
+
+	// Reads the file
+	byteValue, err := io.ReadAll(jsonFile)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// Parses the json as an slice of Sensors
+	var ss []Sensor
+	json.Unmarshal([]byte(byteValue), &ss)
+
+	// Activates each sensor
+	for i := range ss {
+		ss[i].StartMeasuring(ctx, readings)
+	}
+
+}

--- a/Week03/simulator/stats/stats.go
+++ b/Week03/simulator/stats/stats.go
@@ -1,0 +1,27 @@
+package stats
+
+// CalculateStats computes the average, minimum, and maximum values
+// from a slice of float64 numbers.
+func CalculateStats(data []float64) (avg, min, max float64) {
+
+	sum := 0.0
+	max = data[0]
+	min = data[0]
+
+	for _, d := range data {
+		sum += d
+
+		if d > max {
+			max = d
+		}
+
+		if d < min {
+			min = d
+		}
+	}
+
+	avg = sum / float64(len(data))
+
+	// Return average, minimum, and maximum
+	return avg, min, max
+}


### PR DESCRIPTION

## Structure

Inside `Week03` directory.

- `simulator/`: *idem* to previous task
- `reciever/`:
   -  `config`: new package that reads configuration variables to avoid *magic numbers*
   - `csvutil`: refactor and enhance functions as  a modular app 
   - `httpws`: http server and ws server
   - `logger`: new package that improves the log register
   - `ringbuffer`: data structure defined as a simple linked list where the last element is connected to the first, used on `main.go` to store the last n logs
   - `sensors`: *idem* to previous tasks
   - `states`: contains the state of the server (ON or OFF) used on `httpws` POST actions
   - `main.go`: main file
      - Load settings
      - Create channel to store the data from the sensors 
      - Create `ringbuffer`  to store the last `n` registers
      - Enable TCP server (8080 sensors)
      - Enable the data reception from servers
      - Start HTTP Server
   
## Content 

Create the following routes:

- `GET /api/messages`
- `GET /api/stream → WS`
- `POST /api/command` (JSON type-content) Posible actions
 -  STOP, PAUSE: stop receiving packages
 -  CLEAR, CLEAN: removes the content of the CSV file
 -  CONTINUE: continues receiving packages